### PR TITLE
Added customizable LIBFT_PATH variable to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .DEFAULT_GOAL	:= a
 UTILS			= $(addprefix utils/, sigsegv.cpp color.cpp check.cpp leaks.cpp)
+LIBFT_PATH		= ..
 TESTS_PATH		= tests/
 MANDATORY		= memset bzero memcpy memccpy memmove memchr memcmp strlen isalpha isdigit isalnum \
 				isascii isprint toupper tolower strchr strrchr strncmp strlcpy strlcat strnstr \
@@ -10,7 +11,7 @@ VSOPEN			= $(addprefix vs, $(MANDATORY)) $(addprefix vs, $(BONUS))
 MAIL			= $(addprefix send, $(MANDATORY)) $(addprefix send, $(BONUS))
 
 CC		= clang++
-CFLAGS	= -g3 -ldl -std=c++11 -I utils/ -I..
+CFLAGS	= -g3 -ldl -std=c++11 -I utils/ -I$(LIBFT_PATH)
 
 UNAME = $(shell uname -s)
 ifeq ($(UNAME), Linux)
@@ -18,25 +19,25 @@ ifeq ($(UNAME), Linux)
 endif
 
 $(MANDATORY): %: mandatory_start
-	@$(CC) $(CFLAGS) $(UTILS) $(TESTS_PATH)ft_$*_test.cpp -L.. -lft && $(VALGRIND) ./a.out && rm -f a.out
+	@$(CC) $(CFLAGS) $(UTILS) $(TESTS_PATH)ft_$*_test.cpp -L$(LIBFT_PATH) -lft && $(VALGRIND) ./a.out && rm -f a.out
 
 $(BONUS): %: bonus_start
-	@$(CC) $(CFLAGS) $(UTILS) $(TESTS_PATH)ft_$*_test.cpp -L.. -lft && $(VALGRIND) ./a.out && rm -f a.out
+	@$(CC) $(CFLAGS) $(UTILS) $(TESTS_PATH)ft_$*_test.cpp -L$(LIBFT_PATH) -lft && $(VALGRIND) ./a.out && rm -f a.out
 
 $(VSOPEN): vs%:
 	@code $(TESTS_PATH)ft_$*_test.cpp
 
 $(MAIL): send%:
-	cat ../ft_$*.c | mail -s "libftTester Improvement $*" jgambard@student.42lyon.fr
+	cat $(LIBFT_PATH)/ft_$*.c | mail -s "libftTester Improvement $*" jgambard@student.42lyon.fr
 
 mandatory_start: update message
 	@tput setaf 6
-	make -C ..
+	make -C $(LIBFT_PATH)
 	@tput setaf 4 && echo [Mandatory]
 
 bonus_start: update message
 	@tput setaf 6
-	make bonus -C ..
+	make bonus -C $(LIBFT_PATH)
 	@tput setaf 5 && echo [Bonus]
 
 update:
@@ -46,7 +47,7 @@ message: checkmakefile
 	@tput setaf 3 && echo If all your tests are OK and the moulinette KO you, please send an email with make sendfunction ex: make sendsubstr
 
 checkmakefile:
-	@ls .. | grep Makefile > /dev/null 2>&1 || (tput setaf 1 && echo Makefile not found. && exit 1)
+	@ls $(LIBFT_PATH) | grep Makefile > /dev/null 2>&1 || (tput setaf 1 && echo Makefile not found. && exit 1)
 
 $(addprefix docker, $(MANDATORY)) $(addprefix docker, $(BONUS)) dockerm dockerb dockera: docker%:
 	@docker rm -f mc > /dev/null 2>&1 || true
@@ -60,9 +61,9 @@ b: $(BONUS)
 a: m b 
 
 clean:
-	make clean -C .. && rm -rf a.out*
+	make clean -C $(LIBFT_PATH) && rm -rf a.out*
 
 fclean:
-	make fclean -C .. && rm -rf a.out*
+	make fclean -C $(LIBFT_PATH) && rm -rf a.out*
 
 .PHONY:	mandatory_start m bonus_start b a fclean clean update message $(VSOPEN) $(MAIL)

--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
 # libftTester (2019+)
 
-Tester for the libft project of 42 school (with personalized leaks checking on mac, using valgrind on linux)  
-*If all your tests are OK and the moulinette KO you, please send an email with make sendfunction ex: make sendsubstr or contact me on slack/discord for improvements*  
-Clone this tester in your libft repository. (works on linux and mac)  
+Tester for the libft project of 42 school (with personalized leaks checking on mac, using valgrind on linux)
+*If all your tests are OK and the moulinette KO you, please send an email with make sendfunction ex: make sendsubstr or contact me on slack/discord for improvements*
+Clone this tester in your libft repository. (works on linux and mac)
 ![alt text](https://i.imgur.com/EWmbpxx.png)
 
 
 # Commands
-make m = launch mandatory tests  
-make b = launch bonus tests  
-make a = launch mandatory tests + bonus tests  
-make [funtion name] = launch associated test ex: make calloc  
+make m = launch mandatory tests
+make b = launch bonus tests
+make a = launch mandatory tests + bonus tests
+make [funtion name] = launch associated test ex: make calloc
  
-make dockerm = launch mandatory tests in linux container   
-make dockerb = launch bonus tests in linux container   
-make dockera = launch mandatory tests + bonus tests in linux container  
-make docker[funtion name] = launch associated test in linux container ex: make dockercalloc  
-Thanks to gurival- for the docker idea (https://github.com/grouville/valgrind_42)  
+make dockerm = launch mandatory tests in linux container
+make dockerb = launch bonus tests in linux container
+make dockera = launch mandatory tests + bonus tests in linux container
+make docker[funtion name] = launch associated test in linux container ex: make dockercalloc
+Thanks to gurival- for the docker idea (https://github.com/grouville/valgrind_42)
 
-make vs[funtion name] = open the corresponding tests in vscode ex: make vscalloc  
+make vs[funtion name] = open the corresponding tests in vscode ex: make vscalloc
+
+# Libft Path
+You can customize the path to your libft project by changing the `LIBFT_PATH` variable inside the `Makefile`. The default value is `..`.
 
 # Outputs
 
-![alt text](https://i.imgur.com/en8rJpS.png)  
-![alt text](https://i.imgur.com/ZvzhIoZ.png)  
-![alt text](https://i.imgur.com/KrlN2Pg.png)  
+![alt text](https://i.imgur.com/en8rJpS.png)
+![alt text](https://i.imgur.com/ZvzhIoZ.png)
+![alt text](https://i.imgur.com/KrlN2Pg.png)
 
-MOK / MKO = test about your malloc size (this shouldn't be tested by moulinette)  
+MOK / MKO = test about your malloc size (this shouldn't be tested by moulinette)
 
 # Report bugs / Improvement
-Contact me on slack or discord : jgambard or use make sendfunction ex make sendsubstr if all your tests were OK and the moulinette KO you.  
+Contact me on slack or discord : jgambard or use make sendfunction ex make sendsubstr if all your tests were OK and the moulinette KO you.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Thanks to gurival- for the docker idea (https://github.com/grouville/valgrind_42
 make vs[funtion name] = open the corresponding tests in vscode ex: make vscalloc
 
 # Libft Path
-You can customize the path to your libft project by changing the `LIBFT_PATH` variable inside the `Makefile`. The default value is `..`.
+You can customize the path to your libft project by changing the `LIBFT_PATH` variable inside the `Makefile`. The default value is `..` (previous directory)
 
 # Outputs
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,34 @@
 # libftTester (2019+)
 
-Tester for the libft project of 42 school (with personalized leaks checking on mac, using valgrind on linux)
-*If all your tests are OK and the moulinette KO you, please send an email with make sendfunction ex: make sendsubstr or contact me on slack/discord for improvements*
-Clone this tester in your libft repository. (works on linux and mac)
-![alt text](https://i.imgur.com/EWmbpxx.png)
+Tester for the libft project of 42 school (with personalized leaks checking on mac, using valgrind on linux)  
+*If all your tests are OK and the moulinette KO you, please send an email with make sendfunction ex: make sendsubstr or contact me on slack/discord for improvements*  
+Clone this tester in your libft repository, or somewhere else and customize the path to your libft project by changing the LIBFT_PATH variable inside the Makefile.  
+
+![alt text](https://i.imgur.com/EWmbpxx.png)  
 
 
 # Commands
-make m = launch mandatory tests
-make b = launch bonus tests
-make a = launch mandatory tests + bonus tests
-make [funtion name] = launch associated test ex: make calloc
+make m = launch mandatory tests  
+make b = launch bonus tests  
+make a = launch mandatory tests + bonus tests  
+make [funtion name] = launch associated test ex: make calloc  
  
-make dockerm = launch mandatory tests in linux container
-make dockerb = launch bonus tests in linux container
-make dockera = launch mandatory tests + bonus tests in linux container
-make docker[funtion name] = launch associated test in linux container ex: make dockercalloc
-Thanks to gurival- for the docker idea (https://github.com/grouville/valgrind_42)
+make dockerm = launch mandatory tests in linux container  
+make dockerb = launch bonus tests in linux container  
+make dockera = launch mandatory tests + bonus tests in linux container  
+make docker[funtion name] = launch associated test in linux container ex: make dockercalloc  
+Thanks to gurival- for the docker idea (https://github.com/grouville/valgrind_42)  
 
-make vs[funtion name] = open the corresponding tests in vscode ex: make vscalloc
+make vs[funtion name] = open the corresponding tests in vscode ex: make vscalloc  
 
-# Libft Path
-You can customize the path to your libft project by changing the `LIBFT_PATH` variable inside the `Makefile`. The default value is `..` (previous directory)
 
 # Outputs
 
-![alt text](https://i.imgur.com/en8rJpS.png)
-![alt text](https://i.imgur.com/ZvzhIoZ.png)
-![alt text](https://i.imgur.com/KrlN2Pg.png)
+![alt text](https://i.imgur.com/en8rJpS.png)  
+![alt text](https://i.imgur.com/ZvzhIoZ.png)  
+![alt text](https://i.imgur.com/KrlN2Pg.png)  
 
-MOK / MKO = test about your malloc size (this shouldn't be tested by moulinette)
+MOK / MKO = test about your malloc size (this shouldn't be tested by moulinette)  
 
 # Report bugs / Improvement
-Contact me on slack or discord : jgambard or use make sendfunction ex make sendsubstr if all your tests were OK and the moulinette KO you.
+Contact me on slack or discord : jgambard or use make sendfunction ex make sendsubstr if all your tests were OK and the moulinette KO you.  


### PR DESCRIPTION
I added the variable `LIBFT_PATH` to the `Makefile`, allowing users to specify a custom path to their libft project ([a96a628](https://github.com/Tripouille/libftTester/commit/a96a6286ced7ac09c1466e76d68acf162e430879)).
Also, the [README](https://github.com/brhaka/libftTester/blob/0feef9710c81f136d7e89d3e33eb9cfc65a2faf4/README.md) was updated and contains information about this new variable.