### PR TITLE
Added information about the use of relative paths on the LIBFT_PATH variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # libftTester (2019+)
 Tester for the libft project of 42 school (with personalized leaks checking on mac, using valgrind on linux)  
 *If all your tests are OK and the moulinette KO you, please send an email with make sendfunction ex: make sendsubstr or contact me on slack/discord for improvements*  
-Clone this tester in your libft repository, or somewhere else and customize the path to your libft project by changing the LIBFT_PATH variable inside the Makefile. Relative paths may not work correctly depending on the OS, so if you face any issues, try using an absolute path instead.
+Clone this tester in your libft repository, or somewhere else and customize the path to your libft project by changing the LIBFT_PATH variable inside the Makefile. Relative paths (`../`) may not work correctly depending on the OS, so if you face any issues, try using an absolute path instead (`/Users/****/`).
 
 ![alt text](https://i.imgur.com/EWmbpxx.png)  
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # libftTester (2019+)
 Tester for the libft project of 42 school (with personalized leaks checking on mac, using valgrind on linux)  
 *If all your tests are OK and the moulinette KO you, please send an email with make sendfunction ex: make sendsubstr or contact me on slack/discord for improvements*  
-Clone this tester in your libft repository, or somewhere else and customize the path to your libft project by changing the LIBFT_PATH variable inside the Makefile.  
+Clone this tester in your libft repository, or somewhere else and customize the path to your libft project by changing the LIBFT_PATH variable inside the Makefile. Relative paths may not work correctly depending on the OS, so if you face any issues, try using an absolute path instead.
 
 ![alt text](https://i.imgur.com/EWmbpxx.png)  
 


### PR DESCRIPTION
Relative paths may not work properly on some OS. MacOS will most likely require an absolute path, while relative paths are an option on Ubuntu.
I added this information which I consider important to the README, to avoid people having issues regarding relative and absolute paths.