### PR TITLE
[FIX] Test adjustment in the function ft_strrchr.c

### DIFF
--- a/tests/ft_strrchr_test.cpp
+++ b/tests/ft_strrchr_test.cpp
@@ -17,14 +17,17 @@ int main(void)
 	title("ft_strrchr\t: ")
 	char s[] = "tripouille";
 	char s2[] = "ltripouiel";
+	char s3[] = "taxtripouille";
+
 	/* 1 */ check(ft_strrchr(s, 't') == s); showLeaks();
 	/* 2 */ check(ft_strrchr(s, 'l') == s + 8); showLeaks();
 	/* 3 */ check(ft_strrchr(s2, 'l') == s2 + 9); showLeaks();
 	/* 4 */ check(ft_strrchr(s, 'z') == NULL); showLeaks();
 	/* 5 */ check(ft_strrchr(s, 0) == s + strlen(s)); showLeaks();
 	/* 6 */ check(ft_strrchr(s, 't' + 256) == s); showLeaks();
+	/* 7 */ check(ft_strrchr(s3, 'x') == s3 + 3); showLeaks();
 	char * empty = (char*)calloc(1, 1);
-	/* 7 aperez-b */ check(ft_strrchr(empty, 'V') == NULL); free(empty); showLeaks();
+	/* 8 aperez-b */ check(ft_strrchr(empty, 'V') == NULL); free(empty); showLeaks();
 	write(1, "\n", 1);
 	return (0);
 }


### PR DESCRIPTION
fix #5 
### Here's the output from Deepthought: 

**Testing ft_strrchr**
 **[!] Error** - Expected: 1Hq3g 8HzxvNVf 9wPx7JlOqi 74mY96Hl - **Got:** (null)
 **[!] Error** - Expected: Qcz pWqvLo5T3 A7OkVYM0x4Gmp 7P5rXpobA G5lXuCsK vVDgTSI7PmUf6b - **Got:** (null)
 **[!] Error** - Expected: p 2vwkQcb1l5oUMteI qCrvUXZHKdI6AtYJ J9dK1aoEXBk mI4V03R EYULCNDnXcFb4jy UFDTIXo3AH9r SyvA86EM9YcnI kVqELG evM1 gL2xMQz5oF jrkNh5 VT8 - **Got:** (null)
 **[!] Error** - Expected: pcAHwIz3Y Am1QXbwCPI75c qwh9 EdlogBmcq86MIkzY4 VTGnwItz7h OvuhUbygHZ8iXSC - **Got:** (null)
 **[!] Error** - Expected: Re cvydEMXk XPYy9zFOx 2qtZaK5A1Q70kML - **Got:** (null)
 **[!] Error** - Expected: 6Xkabn205xKFOsoh tpXhSBA7Qc WbnZ4D3xhXFY zxEFQWqvSoNkZDV 9zr KjqPoz7Zaudm CLBZnks7dO5EVWYtw Ms7ODad8TFuXLfe - **Got:** (null)
 **[!] Error** - Expected: c9 NruYzaLJtp8 bUBvsF43Ikn 4yg0DndRMHF - **Got:** (null)