### PR TITLE
File permission (tripouille) failed to read on some systems (42SP Workspace)

### DIFF
--- a/tests/ft_putnbr_fd_test.cpp
+++ b/tests/ft_putnbr_fd_test.cpp
@@ -20,35 +20,35 @@ int main(void)
 	signal(SIGSEGV, sigsegv);
 	title("ft_putnbr_fd\t: ")
 
-	int fd = open("tripouille", O_RDWR | O_CREAT);
+	int fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(0, fd);
 	lseek(fd, SEEK_SET, 0);
 	char s[42] = {0}; read(fd, s, 2);
 	/* 1 */ check(!strcmp(s, "0")); showLeaks();
 	unlink("./tripouille");
 
-	fd = open("tripouille", O_RDWR | O_CREAT);
+	fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(10, fd);
 	lseek(fd, SEEK_SET, 0);
 	read(fd, s, 3);
 	/* 2 */ check(!strcmp(s, "10")); showLeaks();
 	unlink("./tripouille");
 
-	fd = open("tripouille", O_RDWR | O_CREAT);
+	fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(INT_MAX, fd);
 	lseek(fd, SEEK_SET, 0);
 	read(fd, s, 11);
 	/* 3 */ check(!strcmp(s, to_string(INT_MAX).c_str())); showLeaks();
 	unlink("./tripouille");
 
-	fd = open("tripouille", O_RDWR | O_CREAT);
+	fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(INT_MIN, fd);
 	lseek(fd, SEEK_SET, 0);
 	read(fd, s, 12);
 	/* 4 */ check(!strcmp(s, to_string(INT_MIN).c_str())); showLeaks();
 	unlink("./tripouille");
 
-	fd = open("tripouille", O_RDWR | O_CREAT);
+	fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(-42, fd);
 	lseek(fd, SEEK_SET, 0);
 	s[read(fd, s, 4)] = 0;


### PR DESCRIPTION
Here at 42Sp we are using a new system where we have the codeserver workspace, we noticed that the ft_putnbr_fd test fails to read the file (no permission), I added 0777 to file permission for a while.

![file_permission](https://user-images.githubusercontent.com/38966653/142741215-44b6aafd-9b65-4633-a9af-321f29288708.png)
