### PR TITLE
add test for calloc

### DIFF
--- a/tests/ft_calloc_test.cpp
+++ b/tests/ft_calloc_test.cpp
@@ -20,6 +20,7 @@ int main(void)
 	char e[] = {0, 0, 0, 0};
 	/* 1 */ check(!memcmp(p, e, 4));
 	/* 2 */ mcheck(p, 4); free(p); showLeaks();
+	/* 3 */ check(ft_calloc(SIZE_MAX, SIZE_MAX) == NULL);
 	write(1, "\n", 1);
 	return (0);
 }


### PR DESCRIPTION
in man we can read :
> If the multiplication of nmemb and size would result in integer overflow, then calloc() returns an error.
my implementation for this is the follow :
```
void	*ft_calloc(size_t nmemb, size_t size)
{
...
	if (n_bytes / size != nmemb)
		return (NULL);
...
}
```
is that the right way?