### PR TITLE
Fixed calloc

### DIFF
--- a/tests/ft_calloc_test.cpp
+++ b/tests/ft_calloc_test.cpp
@@ -17,10 +17,11 @@ int main(void)
 	title("ft_calloc\t: ")
 
 	void * p = ft_calloc(2, 2);
+	void * p2 = ft_calloc(SIZE_MAX, SIZE_MAX);
 	char e[] = {0, 0, 0, 0};
 	/* 1 */ check(!memcmp(p, e, 4));
-	/* 2 */ mcheck(p, 4); free(p); showLeaks();
-	/* 3 */ check(ft_calloc(SIZE_MAX, SIZE_MAX) == NULL);
+	/* 2 */ mcheck(p, 4); free(p);
+	/* 3 */ check(p2 == NULL); free(p2); showLeaks();
 	write(1, "\n", 1);
 	return (0);
 }

--- a/tests/ft_putnbr_fd_test.cpp
+++ b/tests/ft_putnbr_fd_test.cpp
@@ -20,35 +20,35 @@ int main(void)
 	signal(SIGSEGV, sigsegv);
 	title("ft_putnbr_fd\t: ")
 
-	int fd = open("tripouille", O_RDWR | O_CREAT);
+	int fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(0, fd);
 	lseek(fd, SEEK_SET, 0);
 	char s[42] = {0}; read(fd, s, 2);
 	/* 1 */ check(!strcmp(s, "0")); showLeaks();
 	unlink("./tripouille");
 
-	fd = open("tripouille", O_RDWR | O_CREAT);
+	fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(10, fd);
 	lseek(fd, SEEK_SET, 0);
 	read(fd, s, 3);
 	/* 2 */ check(!strcmp(s, "10")); showLeaks();
 	unlink("./tripouille");
 
-	fd = open("tripouille", O_RDWR | O_CREAT);
+	fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(INT_MAX, fd);
 	lseek(fd, SEEK_SET, 0);
 	read(fd, s, 11);
 	/* 3 */ check(!strcmp(s, to_string(INT_MAX).c_str())); showLeaks();
 	unlink("./tripouille");
 
-	fd = open("tripouille", O_RDWR | O_CREAT);
+	fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(INT_MIN, fd);
 	lseek(fd, SEEK_SET, 0);
 	read(fd, s, 12);
 	/* 4 */ check(!strcmp(s, to_string(INT_MIN).c_str())); showLeaks();
 	unlink("./tripouille");
 
-	fd = open("tripouille", O_RDWR | O_CREAT);
+	fd = open("tripouille", O_RDWR | O_CREAT, 0777);
 	ft_putnbr_fd(-42, fd);
 	lseek(fd, SEEK_SET, 0);
 	s[read(fd, s, 4)] = 0;


### PR DESCRIPTION
When calloc can allloc SIZE_MAX, the pointer needs to be free.

![calloc](https://user-images.githubusercontent.com/38966653/166080126-b08cec43-8983-4afd-a87b-963f4e028b4d.png)
