### PR TITLE
add errno test for calloc

### DIFF
--- a/tests/ft_calloc_test.cpp
+++ b/tests/ft_calloc_test.cpp
@@ -9,6 +9,7 @@ extern "C"
 #include "check.hpp"
 #include "leaks.hpp"
 #include <string.h>
+#include <errno.h>
 
 int iTest = 1;
 int main(void)
@@ -21,6 +22,7 @@ int main(void)
 	/* 1 */ check(!memcmp(p, e, 4));
 	/* 2 */ mcheck(p, 4); free(p); showLeaks();
 	/* 3 */ check(ft_calloc(SIZE_MAX, SIZE_MAX) == NULL);
+	/* 4 */ check(errno == ENOMEM);
 	write(1, "\n", 1);
 	return (0);
 }


### PR DESCRIPTION
ERRORS
       calloc(), malloc(), realloc(), and reallocarray() can fail with the following error:

       ENOMEM Out  of memory.