### PR TITLE
Test with empty string and c == 0

### DIFF
--- a/tests/ft_strrchr_test.cpp
+++ b/tests/ft_strrchr_test.cpp
@@ -17,6 +17,7 @@ int main(void)
 	title("ft_strrchr\t: ")
 	char s[] = "tripouille";
 	char s2[] = "ltripouiel";
+	char s3[] = "";
 	/* 1 */ check(ft_strrchr(s, 't') == s); showLeaks();
 	/* 2 */ check(ft_strrchr(s, 'l') == s + 8); showLeaks();
 	/* 3 */ check(ft_strrchr(s2, 'l') == s2 + 9); showLeaks();
@@ -25,6 +26,7 @@ int main(void)
 	/* 6 */ check(ft_strrchr(s, 't' + 256) == s); showLeaks();
 	char * empty = (char*)calloc(1, 1);
 	/* 7 aperez-b */ check(ft_strrchr(empty, 'V') == NULL); free(empty); showLeaks();
+	/* 8 */ check(ft_strrchr(s3, 0) == s3); showLeaks();
 	write(1, "\n", 1);
 	return (0);
 }


### PR DESCRIPTION
When you create a empty string ("") and put strrchr(empty, 0), the expected result is an empty return (./a.out | cat -e without anything) but not a null one. (./a.out | cat -e with (null)). I believe this test make your tester even stronger : )