### PR TITLE
Fix compilation error for the bonus part (type casting)

### DIFF
--- a/tests/ft_lstadd_back_test.cpp
+++ b/tests/ft_lstadd_back_test.cpp
@@ -10,7 +10,7 @@ extern "C"
 #include "leaks.hpp"
 #include <string.h>
 
-void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
+void freeList(t_list *head) {if (head) freeList((t_list *)head->next); free(head);}
 
 int iTest = 1;
 int main(void)
@@ -18,24 +18,24 @@ int main(void)
 	signal(SIGSEGV, sigsegv);
 	title("ft_lstadd_back\t: ")
 
-	t_list * l =  NULL; t_list * l2 =  NULL; 
+	t_list * l =  NULL; t_list * l2 =  NULL;
 	ft_lstadd_back(&l, ft_lstnew((void*)1));
 	/* 1 */ check(l->content == (void*)1);
 	/* 2 */ check(l->next == 0);
 
 	ft_lstadd_back(&l, ft_lstnew((void*)2));
 	/* 3 */ check(l->content == (void*)1);
-	/* 4 */ check(l->next->content == (void*)2);
-	/* 5 */ check(l->next->next == 0);
+	/* 4 */ check(((t_list *)(l->next))->content == (void*)2);
+	/* 5 */ check(((t_list *)(l->next))->next == 0);
 
 	ft_lstadd_back(&l2, ft_lstnew((void*)3));
 	ft_lstadd_back(&l2, ft_lstnew((void*)4));
 	ft_lstadd_back(&l, l2);
 	/* 6 */ check(l->content == (void*)1);
-	/* 7 */ check(l->next->content == (void*)2);
-	/* 8 */ check(l->next->next->content == (void*)3);
-	/* 9 */ check(l->next->next->next->content == (void*)4);
-	/* 10 */ check(l->next->next->next->next == 0);
+	/* 7 */ check(((t_list *)(l->next))->content == (void*)2);
+	/* 8 */ check(((t_list *)(((t_list *)(l->next))->next))->content == (void*)3);
+	/* 9 */ check(((t_list *)((t_list *)(((t_list *)(l->next))->next))->next)->content == (void*)4);
+	/* 10 */ check(((t_list *)((t_list *)(((t_list *)(l->next))->next))->next)->next == 0);
 	freeList(l); showLeaks();
 	write(1, "\n", 1);
 	return (0);

--- a/tests/ft_lstadd_front_test.cpp
+++ b/tests/ft_lstadd_front_test.cpp
@@ -10,7 +10,7 @@ extern "C"
 #include "leaks.hpp"
 #include <string.h>
 
-void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
+void freeList(t_list *head) {if (head) freeList((t_list *)head->next); free(head);}
 
 int iTest = 1;
 int main(void)
@@ -25,8 +25,8 @@ int main(void)
 
 	ft_lstadd_front(&l, ft_lstnew((void*)2));
 	/* 3 */ check(l->content == (void*)2);
-	/* 4 */ check(l->next->content == (void*)1);
-	/* 5 */ check(l->next->next == 0); 
+	/* 4 */ check(((t_list *)l->next)->content == (void*)1);
+	/* 5 */ check(((t_list *)l->next)->next == 0);
 	freeList(l); showLeaks();
 	write(1, "\n", 1);
 	return (0);

--- a/tests/ft_lstclear_test.cpp
+++ b/tests/ft_lstclear_test.cpp
@@ -10,7 +10,7 @@ extern "C"
 #include "leaks.hpp"
 #include <string.h>
 
-void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
+void freeList(t_list *head) {if (head) freeList((t_list *)head->next); free(head);}
 
 int iTest = 1;
 int main(void)

--- a/tests/ft_lstdelone_test.cpp
+++ b/tests/ft_lstdelone_test.cpp
@@ -10,7 +10,7 @@ extern "C"
 #include "leaks.hpp"
 #include <string.h>
 
-void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
+void freeList(t_list *head) {if (head) freeList((t_list *)head->next); free(head);}
 
 int iTest = 1;
 int main(void)

--- a/tests/ft_lstiter_test.cpp
+++ b/tests/ft_lstiter_test.cpp
@@ -10,7 +10,7 @@ extern "C"
 #include "leaks.hpp"
 #include <string.h>
 
-void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
+void freeList(t_list *head) {if (head) freeList((t_list *)head->next); free(head);}
 void addOne(void * p) {++*(int*)p;}
 
 int iTest = 1;
@@ -28,7 +28,7 @@ int main(void)
 	/* 1 2 3 4 */ for (int i = 0; i < 4; ++i)
 	{
 		check(*(int*)tmp->content == i + 1);
-		tmp = tmp->next;
+		tmp = (t_list *)tmp->next;
 	}
 	freeList(l); showLeaks();
 	write(1, "\n", 1);

--- a/tests/ft_lstlast_test.cpp
+++ b/tests/ft_lstlast_test.cpp
@@ -10,7 +10,7 @@ extern "C"
 #include "leaks.hpp"
 #include <string.h>
 
-void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
+void freeList(t_list *head) {if (head) freeList((t_list *)head->next); free(head);}
 
 int iTest = 1;
 int main(void)

--- a/tests/ft_lstmap_test.cpp
+++ b/tests/ft_lstmap_test.cpp
@@ -10,7 +10,7 @@ extern "C"
 #include "leaks.hpp"
 #include <string.h>
 
-void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
+void freeList(t_list *head) {if (head) freeList((t_list *)head->next); free(head);}
 void * addOne(void * p) {void * r = malloc(sizeof(int)); *(int*)r = *(int*)p + 1; return (r);}
 
 int iTest = 1;
@@ -28,13 +28,13 @@ int main(void)
 	/* 1 2 3 4 */ for (int i = 0; i < 4; ++i)
 	{
 		check(*(int*)tmp->content == i);
-		tmp = tmp->next;
+		tmp = (t_list *)tmp->next;
 	}
 	tmp = m;
 	/* 5 6 7 8 */ for (int i = 0; i < 4; ++i)
 	{
 		check(*(int*)tmp->content == i + 1);
-		tmp = tmp->next;
+		tmp = (t_list *)tmp->next;
 	}
 	freeList(l); ft_lstclear(&m, free); showLeaks();
 	write(1, "\n", 1);

--- a/tests/ft_lstsize_test.cpp
+++ b/tests/ft_lstsize_test.cpp
@@ -10,7 +10,7 @@ extern "C"
 #include "leaks.hpp"
 #include <string.h>
 
-void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
+void freeList(t_list *head) {if (head) freeList((t_list *)head->next); free(head);}
 
 int iTest = 1;
 int main(void)


### PR DESCRIPTION
I have encountered many compilation error on the bonus part (error sample below)
This is my attempt to solve them!
Hopefully it can be useful :)

Test env. :
- Arch Linux x86_64 
- macOS Catalina 10.15.7 (VM)

Encountered errors:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
tests/ft_lstadd_front_test.cpp:13:40: error: no matching function for call to 'freeList'
void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
                                       ^~~~~~~~
tests/ft_lstadd_front_test.cpp:13:6: note: candidate function not viable: cannot convert argument of incomplete type 'void *' to 't_list *' (aka 's_list *') for 1st argument
void freeList(t_list *head) {if (head) freeList(head->next); free(head);}
     ^                                          ~~~~~~~~~~
tests/ft_lstadd_front_test.cpp:28:23: error: member reference base type 'void' is not a structure or union
        /* 4 */ check(l->next->content == (void*)1);
                      ~~~~~~~^ ~~~~~~~
tests/ft_lstadd_front_test.cpp:29:23: error: member reference base type 'void' is not a structure or union
        /* 5 */ check(l->next->next == 0); 
                      ~~~~~~~^ ~~~~