### PR TITLE
update - ft_calloc, test should null when insert zero

### DIFF
--- a/tests/ft_calloc_test.cpp
+++ b/tests/ft_calloc_test.cpp
@@ -21,6 +21,7 @@ int main(void)
 	/* 1 */ check(!memcmp(p, e, 4));
 	/* 2 */ mcheck(p, 4); free(p); showLeaks();
 	/* 3 */ check(ft_calloc(SIZE_MAX, SIZE_MAX) == NULL);
+	/* 4 */ check(ft_calloc(0, 0) == NULL);
 	write(1, "\n", 1);
 	return (0);
 }


### PR DESCRIPTION
In May 2023, the moulinette test in São Paulo, BR for the *ft_calloc( 0, 0) function. Expect ft_calloc to return NULL