### PR TITLE
Fix: Dockerfile: Git detected dubious ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 FROM debian:buster-slim
-RUN apt-get update && apt-get -y upgrade && apt-get install -y git build-essential clang valgrind \
-    && mkdir -m 666 /project
+
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get install -y git build-essential clang valgrind
+
+# Silence all warnings related to Git's safe.directory system.
+RUN git config --global --add safe.directory '*'
+
+RUN mkdir -m 666 /project
 WORKDIR /project


### PR DESCRIPTION
make: Entering directory '/project/libftTester'
fatal: detected dubious ownership in repository at '/project/libftTester' To add an exception for this directory, call:

        git config --global --add safe.directory /project/libftTester
make: *** [Makefile:43: update] Error 128
make: Leaving directory '/project/libftTester'