### PR TITLE
Fix: Add <cstdint> import to define SIZE_MAX on Ubuntu 24

### DIFF
--- a/tests/ft_calloc_test.cpp
+++ b/tests/ft_calloc_test.cpp
@@ -10,6 +10,7 @@ extern "C"
 #include "leaks.hpp"
 #include <string.h>
 #include <limits.h>
+#include <cstdint>
 
 int iTest = 1;
 int main(void)


### PR DESCRIPTION
I added the `cstdint` import because, although `SIZE_MAX` is technically optional, it was undefined on my device (Ubuntu 24). While it worked fine on other devices (like Ubuntu 22), the absence of this import caused issues on my setup, leading to compilation errors. Including cstdint ensures `SIZE_MAX` is properly defined and resolves the issue.

The error:
```bash
tests/ft_calloc_test.cpp:25:26: error: use of undeclared identifier 'SIZE_MAX'
   25 |         /* 3 */ check(ft_calloc(SIZE_MAX, SIZE_MAX) == NULL); showLeaks();
      |                                 ^
tests/ft_calloc_test.cpp:25:36: error: use of undeclared identifier 'SIZE_MAX'
   25 |         /* 3 */ check(ft_calloc(SIZE_MAX, SIZE_MAX) == NULL); showLeaks();
      |                                           ^
2 errors generated.
make: *** [Makefile:24: calloc] Error 1
```