### PR TITLE
New test for ft_substr

### DIFF
--- a/tests/ft_substr_test.cpp
+++ b/tests/ft_substr_test.cpp
@@ -50,6 +50,10 @@ int main(void)
 	/* 15  dfarhi */ check(!strcmp(s, "es"));
 	/* 16  dfarhi */ mcheck(s, 3); free(s); showLeaks();
 
+	s = ft_substr("1234567890", 9, 8);
+        /* 17  rmarcos */ check(!strcmp(s, "0"));
+        /* 18  rmarcos */ mcheck(s, 2); free(s); showLeaks();
+
 	write(1, "\n", 1);
 	return (0);
 }


### PR DESCRIPTION
This new test helps to check if allocated memory is excessive when we start close to the end of the string and `len` is less than the length of the string.

Previous tests do not take this in account, mbueno-g's test helped me to find this out.