### PR TITLE
Fix leaks test for calloc

### DIFF
--- a/tests/ft_calloc_test.cpp
+++ b/tests/ft_calloc_test.cpp
@@ -28,7 +28,7 @@ int main(void)
 	/* The following tests are not supported by the function's documentation. 
  	* But some effects returned in the trait by Moulinette so the following 
   	* tests were implemented. */
-	/* 4 */ check(ft_calloc(INT_MAX, INT_MAX) == NULL);
+	/* 4 */ check(ft_calloc(INT_MAX, INT_MAX) == NULL); showLeaks();
 	/* 5 */ check(ft_calloc(INT_MIN, INT_MIN) == NULL); showLeaks();
 	p = ft_calloc(0, 0);
 	/* 6 */ check(p != NULL); free(p); showLeaks();


### PR DESCRIPTION
For some time I was trying to figure out what's wrong with my calloc getting INT_MIN, INT_MIN while it was actually leaking because of INT_MAX, INT_MAX. 

The fix leads to showing leaks on the correct test number.