### PR TITLE
Ft_lstdelone extra tests proposal

### DIFF
--- a/tests/ft_lstdelone_test.cpp
+++ b/tests/ft_lstdelone_test.cpp
@@ -11,42 +11,30 @@ extern "C"
 #include <string.h>
 #include <stdlib.h>
 static int del_called = 0;
-void dummy_del(void *p)
-{
-	free(p);
-	del_called = 1;
-}
+void dummy_del(void *p) { free(p); del_called = 1; }
 int iTest = 1;
 int main(void)
 {
-	signal(SIGSEGV, sigsegv);
-	(void)iTest;
+	signal(SIGSEGV, sigsegv); (void)iTest;
 	title("ft_lstdelone\t: ");
 	t_list *l = ft_lstnew(malloc(4));
 	ft_lstdelone(l, dummy_del);
-	/* 1 */ check(del_called == 1);
-
+	/* 1 */check(del_called == 1);
 	t_list *l2 = ft_lstnew(NULL);
 	ft_lstdelone(l2, free);
-	/* 2 */ check(1);
+	/* 2 */check(1);
 
 	t_list *l3 = ft_lstnew(ft_strdup("first"));
 	t_list *mid = ft_lstnew(ft_strdup("middle"));
 	t_list *last = ft_lstnew(ft_strdup("last"));
 	l3->next = mid;
 	mid->next = last;
-
 	ft_lstdelone(mid, free);
 
-	/* 3 */ check(ft_strncmp((char *)l3->content, "first", 5) == 0);
-	/* 4 */ check(ft_strncmp((char *)last->content, "last", 4) == 0);
-
-	free(l3->content);
-	free(last->content);
-	free(last);
-	free(l3);
-
-	showLeaks();
+	/* 3 */check(ft_strncmp((char *)l3->content, "first", 5) == 0);
+	/* 4 */check(ft_strncmp((char *)last->content, "last", 4) == 0);
+	
+	free(l3->content); free(last->content); free(last); free(l3); showLeaks();
 	write(1, "\n", 1);
 	return (0);
-}
+} 


### PR DESCRIPTION
Hi! My name is Ola, and I’m a new cadet from 42 London. While completing libft and using your testing framework (which is an absolute gift — thank you!), I noticed that the ft_lstdelone tests could benefit from a couple of additional cases:

- Testing the first parameter: calling the function with NULL as the list node.
- Testing the second parameter: using a dummy delete function to ensure behavior is consistent.
- Testing deletion of a middle node: verifying that deleting one node does not affect the content of the next node.

I’ve implemented these improvements in my fork and would love to propose them via a pull request.
Please let me know if this aligns with your vision for the project — I’m happy to adjust anything if needed.

Best,
Ola