### PR TITLE
reset terminal color after test output

### DIFF
--- a/utils/check.cpp
+++ b/utils/check.cpp
@@ -6,9 +6,9 @@ extern int iTest;
 void check(bool succes)
 {
 	if (succes)
-		{std::ostringstream ss; ss << FG_GREEN << iTest++ << ".OK "; write(1, ss.str().c_str(), ss.str().size());}
+		{std::ostringstream ss; ss << FG_GREEN << iTest++ << ".OK " << RESET_ALL; write(1, ss.str().c_str(), ss.str().size());}
 	else
-		{std::ostringstream ss; ss << FG_RED << iTest++ << ".KO "; write(1, ss.str().c_str(), ss.str().size());}
+		{std::ostringstream ss; ss << FG_RED << iTest++ << ".KO " << RESET_ALL; write(1, ss.str().c_str(), ss.str().size());}
 }
 
 void mcheck(void * p, size_t required_size)
@@ -20,8 +20,8 @@ void mcheck(void * p, size_t required_size)
 	#ifdef __APPLE__
 	if (malloc_size(p) == malloc_size(p2))
 	#endif
-		{std::ostringstream ss; ss << FG_GREEN << iTest++ << ".MOK "; write(1, ss.str().c_str(), ss.str().size());}
+		{std::ostringstream ss; ss << FG_GREEN << iTest++ << ".MOK " << RESET_ALL; write(1, ss.str().c_str(), ss.str().size());}
 	else
-		{std::ostringstream ss; ss << FG_RED << iTest++ << ".MKO "; write(1, ss.str().c_str(), ss.str().size());}
+		{std::ostringstream ss; ss << FG_RED << iTest++ << ".MKO " << RESET_ALL; write(1, ss.str().c_str(), ss.str().size());}
 	free(p2);
 }

--- a/utils/leaks.cpp
+++ b/utils/leaks.cpp
@@ -48,7 +48,7 @@ void showLeaks(void)
 {
     if (mallocList.size() != 0)
     {
-        std::ostringstream ss; ss << FG_RED << "LEAKS.KO "; write(1, ss.str().c_str(), ss.str().size());
+        std::ostringstream ss; ss << FG_RED << "LEAKS.KO " << RESET_ALL; write(1, ss.str().c_str(), ss.str().size());
         std::vector<ptr>::iterator it = mallocList.begin(); std::vector<ptr>::iterator ite = mallocList.end();
         for (; it != ite; ++it)
             {std::ostringstream ss; ss << "[" << it->p << " : " << it->size << "] "; write(1, ss.str().c_str(), ss.str().size());}

--- a/utils/sigsegv.cpp
+++ b/utils/sigsegv.cpp
@@ -6,6 +6,6 @@ extern int iTest;
 void sigsegv(int signal)
 {
 	(void)signal;
-	cout << FG_LYELLOW << iTest++ << ".SIGSEGV" << ENDL;
+	cout << FG_LYELLOW << iTest++ << ".SIGSEGV" << RESET_ALL << ENDL;
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
**reset terminal font color after test output**

hi!
this PR fixes the persistent terminal font color change that occurs after running the tests

**Changes:**
- added a terminal font color reset (`<< RESET_ALL`) after printing the output from the tests