### PR TITLE
test strtrim with characters from charset in the middle of string

### DIFF
--- a/tests/ft_strtrim_test.cpp
+++ b/tests/ft_strtrim_test.cpp
@@ -47,7 +47,11 @@ int main(void)
 	s = ft_strtrim("abcdba", "acb");
 	/* opsec-infosec 15 */ check(!strcmp(s, "d"));
  	/* opsec-infosec 16 */ mcheck(s, 2); free(s); showLeaks();
-	
+
+	s = ft_strtrim("ababa", "a");
+	/* mogiyadev 17 */ check(!strcmp(s, "bab"));
+ 	/* mogiyadev 18 */ mcheck(s, 4); free(s); showLeaks();
+
 	write(1, "\n", 1);
 	return (0);
 }


### PR DESCRIPTION
This PR adds a test for characters from charset in the middle of string.

For example:
`ft_strtrim("ababa", "a")` should return `"bab"`

This test is very useful and needed and moulinette tests it.