### PR TITLE
tests(strnstr): add test 15. test finding the string when it exists i…

### DIFF
--- a/tests/ft_strnstr_test.cpp
+++ b/tests/ft_strnstr_test.cpp
@@ -34,6 +34,7 @@ int main(void)
 	/* 13 opsec-infosec */ check(ft_strnstr("1", "a", 1) == NULL); showLeaks();
 	/* 14 opsec-infosec */ check(ft_strnstr("22", "b", 2) == NULL); showLeaks();
 	/* 15 */ check(ft_strnstr("22", "22", 3) != NULL); showLeaks();
+	/* 16 */ check(ft_strnstr(haystack, "", 0) == haystack); showLeaks();
 	write(1, "\n", 1);
 	return (0);
 }

--- a/tests/ft_strnstr_test.cpp
+++ b/tests/ft_strnstr_test.cpp
@@ -33,6 +33,7 @@ int main(void)
 	/* 12 mbueno-g */ check(ft_strnstr(haystack, "a", 1) == haystack); showLeaks();
 	/* 13 opsec-infosec */ check(ft_strnstr("1", "a", 1) == NULL); showLeaks();
 	/* 14 opsec-infosec */ check(ft_strnstr("22", "b", 2) == NULL); showLeaks();
+	/* 15 */ check(ft_strnstr("22", "22", 3) != NULL); showLeaks();
 	write(1, "\n", 1);
 	return (0);
 }

--- a/tests/ft_strnstr_test.cpp
+++ b/tests/ft_strnstr_test.cpp
@@ -33,7 +33,7 @@ int main(void)
 	/* 12 mbueno-g */ check(ft_strnstr(haystack, "a", 1) == haystack); showLeaks();
 	/* 13 opsec-infosec */ check(ft_strnstr("1", "a", 1) == NULL); showLeaks();
 	/* 14 opsec-infosec */ check(ft_strnstr("22", "b", 2) == NULL); showLeaks();
-	/* 15 */ check(ft_strnstr("22", "22", 3) != NULL); showLeaks();
+	/* 15 */ { const char *h = "22"; check(ft_strnstr(h, "22", 3) == h); } showLeaks();
 	/* 16 */ check(ft_strnstr(haystack, "", 0) == haystack); showLeaks();
 	write(1, "\n", 1);
 	return (0);


### PR DESCRIPTION
The following ft_strnstr implementation passes in those 14 tests but it fails when trying to find a string that is present in the haystack  and the n bytes to lookup is a number greater than the length of the haystack.

```.c
#include <libft.h>

char *ft_strnstr(const char *haystack, const char *search, size_t n)
{
	size_t	i;
	size_t	j;
	size_t	len;

	i = 0;
	len = ft_strlen(search);
	if (!len && !haystack[0])
		return ((char *)haystack);
	while (i < n && haystack[i])
	{
		j = 0;
		while (i + j < n && haystack[i + j] == search[j])
			j++;
		if (j == len)
			return ((char *)haystack + i);
		i++;
	}
	return ((void *)0);
}

```

The test added in the pull request detects this problem in the above implementation.